### PR TITLE
Update layout_predicates.mzn

### DIFF
--- a/layout_predicates.mzn
+++ b/layout_predicates.mzn
@@ -2,8 +2,6 @@ include "globals.mzn";
 
 
 predicate sorted_except_0(array[int] of var int: x, int: num, int: min, int: max) = 
-  % Possibly only the regular constraint is needed
-  forall(i in 1..length(x)-1)(x[i]<=x[i+1] \/ x[i+1]==0) /\
   regular(x, concat(["(0* \(i)){\(min),\(max)} " | i in 1..num]++["0*"]))::domain;
   
   


### PR DESCRIPTION
I have tested this constraint separately and can confirm that, yes, using only the regular expression is enough. The addition of the first constraint neither improves the performance nor changes the output (except the order of the solutions to test)